### PR TITLE
Fix right analog stick axis for p3 converter model 538

### DIFF
--- a/src/controllers/dinput/p3converter.h
+++ b/src/controllers/dinput/p3converter.h
@@ -52,8 +52,8 @@ uint8_t p3converter_processReport(Controller *c, size_t length)
 
     c->controlData.leftX  = c->buffer[2];
     c->controlData.leftY  = c->buffer[3];
-    c->controlData.rightX = c->buffer[0];
-    c->controlData.rightY = c->buffer[1];
+    c->controlData.rightX = c->buffer[1];
+    c->controlData.rightY = c->buffer[0];
     return 1;
 }
 


### PR DESCRIPTION
Made a mistake when verifying all the inputs with the test plugin.  Right analog stick left/right direction was up/down and vice versa.