### PR TITLE
Add support for Mayflash F500 V2 in XInput mode

### DIFF
--- a/src/devicelist.c
+++ b/src/devicelist.c
@@ -72,6 +72,7 @@ gamepad_t _devices[] = {{PAD_XBOX360, 0x045e, 0x028e},  // Microsoft X-Box 360 p
                         {PAD_XBOX360W, 0x045e, 0x0719}, // Xbox 360 Wireless Receiver
                         {PAD_XBOX360W, 0x045e, 0x0291}, // Xbox 360 Wireless Receiver (xbox)
                         {PAD_XBOX360, 0x045e, 0x02a1}, // Open-Frame1
+                        {PAD_XBOX360, 0x2f24, 0x0087}, // Mayflash F500 V2 [XInput Mode]
 
                         {PAD_XBOX, 0x0d2f, 0x0002},     // Andamiro Pump It Up pad
                         {PAD_XBOX, 0x045e, 0x0202},     // Microsoft X-Box pad v1 (US)


### PR DESCRIPTION
This is working on my PSTV as-is, but I'm attaching the vixen-helper file just in case there's anything I missed.
[vixen.txt](https://github.com/user-attachments/files/23692886/vixen.txt)
