### PR TITLE
Add 8BitDo Ultimate 2 Wireless DInput support

### DIFF
--- a/src/controllers/dinput/ultimate2.h
+++ b/src/controllers/dinput/ultimate2.h
@@ -1,0 +1,54 @@
+uint8_t ultimate2_processReport(Controller *c, size_t length)
+{
+  if (length < 11)
+    return 0;
+
+  process_dpad_angle(c, 1);
+
+  // face buttons
+  if (bit(c->buffer + 8, 0))
+    c->controlData.buttons |= SCE_CTRL_CROSS;
+  if (bit(c->buffer + 8, 1))
+    c->controlData.buttons |= SCE_CTRL_CIRCLE;
+  if (bit(c->buffer + 8, 3))
+    c->controlData.buttons |= SCE_CTRL_SQUARE;
+  if (bit(c->buffer + 8, 4))
+    c->controlData.buttons |= SCE_CTRL_TRIANGLE;
+
+  // bumpers
+  if (bit(c->buffer + 8, 6))
+    c->controlData.buttons |= SCE_CTRL_L1;
+  if (bit(c->buffer + 8, 7))
+    c->controlData.buttons |= SCE_CTRL_R1;
+
+  // triggers
+  c->controlData.lt = c->buffer[7];
+  c->controlData.rt = c->buffer[6];
+
+  if (bit(c->buffer + 9, 0))
+    c->controlData.buttons |= SCE_CTRL_LTRIGGER;
+  if (bit(c->buffer + 9, 1))
+    c->controlData.buttons |= SCE_CTRL_RTRIGGER;
+
+  // select, start and home
+  if (bit(c->buffer + 9, 2))
+    c->controlData.buttons |= SCE_CTRL_SELECT;
+  if (bit(c->buffer + 9, 3))
+    c->controlData.buttons |= SCE_CTRL_START;
+  if (bit(c->buffer + 9, 4))
+    c->controlData.buttons |= SCE_CTRL_PSBUTTON;
+
+  // stick clicks
+  if (bit(c->buffer + 9, 5))
+    c->controlData.buttons |= SCE_CTRL_L3;
+  if (bit(c->buffer + 9, 6))
+    c->controlData.buttons |= SCE_CTRL_R3;
+
+  // sticks
+  c->controlData.leftX  = c->buffer[2];
+  c->controlData.leftY  = c->buffer[3];
+  c->controlData.rightX = c->buffer[4];
+  c->controlData.rightY = c->buffer[5];
+
+  return 1;
+}

--- a/src/controllers/dinput_controller.c
+++ b/src/controllers/dinput_controller.c
@@ -89,7 +89,8 @@ uint8_t DinputController_probe(Controller *c, int device_id, int port, int vendo
       return 0;
 
     // stupid 8bitdo requires reading hid descriptor
-    if (c->vendor == 0x2dc8 && c->product == 0x3105)
+    if (c->vendor == 0x2dc8 &&
+        (c->product == 0x3105 || c->product == 0x6012))
         ksceUsbdGetHidDescriptor(control_pipe_id, NULL, 0, NULL, NULL);
 
     c->attached = 1;

--- a/src/devicelist.c
+++ b/src/devicelist.c
@@ -14,6 +14,7 @@
 #include "controllers/dinput/mayflash.h"
 #include "controllers/dinput/neogeox.h"
 #include "controllers/dinput/8bitdoadapter.h"
+#include "controllers/dinput/ultimate2.h"
 
 gamepad_t _devices[] = {{PAD_XBOX360, 0x045e, 0x028e, NULL},  // Microsoft X-Box 360 pad
                         {PAD_XBOX360, 0x045e, 0x028f, NULL},  // Microsoft X-Box 360 pad v2
@@ -146,5 +147,6 @@ gamepad_t _devices[] = {{PAD_XBOX360, 0x045e, 0x028e, NULL},  // Microsoft X-Box
                         {PAD_DINPUT, 0x1292, 0x4e47, neogeox_processReport},           // NEOGEO X
 
                         {PAD_DINPUT, 0x2dc8, 0x3105, eightbitdoadapter_processReport}, // 8bitdo adapter 2 (dinput mode)
+                        {PAD_DINPUT, 0x2dc8, 0x6012, ultimate2_processReport},         // 8BitDo Ultimate 2 Wireless (DInput)
 
                         {PAD_UNKNOWN, 0x0000, 0x0000, NULL}}; // Null

--- a/src/main.c
+++ b/src/main.c
@@ -44,6 +44,12 @@
 static int started = 0;
 
 static Controller controllers[MAX_CONTROLLERS];
+static int ultimate2_idle_device_ids[MAX_CONTROLLERS] = {-1, -1, -1, -1};
+
+static int is_ultimate2_idle_receiver(uint16_t vendor, uint16_t product)
+{
+  return vendor == 0x2dc8 && product == 0x6013;
+}
 
 static inline int clamp(int value, int min, int max)
 {
@@ -227,6 +233,10 @@ int libvixen_probe(int device_id)
   {
     ksceDebugPrintf("vendor: %04x\n", device->idVendor);
     ksceDebugPrintf("product: %04x\n", device->idProduct);
+
+    if (is_ultimate2_idle_receiver(device->idVendor, device->idProduct))
+      return SCE_USBD_PROBE_SUCCEEDED;
+
     int i;
     for (i = 0; _devices[i].type != PAD_UNKNOWN; i++)
     {
@@ -254,6 +264,27 @@ int libvixen_attach(int device_id)
   {
     ksceDebugPrintf("vendor: %04x\n", device->idVendor);
     ksceDebugPrintf("product: %04x\n", device->idProduct);
+
+    if (is_ultimate2_idle_receiver(device->idVendor, device->idProduct))
+    {
+      for (int i = 0; i < MAX_CONTROLLERS; i++)
+      {
+        if (ultimate2_idle_device_ids[i] == device_id)
+          return SCE_USBD_ATTACH_SUCCEEDED;
+      }
+
+      for (int i = 0; i < MAX_CONTROLLERS; i++)
+      {
+        if (ultimate2_idle_device_ids[i] < 0)
+        {
+          ultimate2_idle_device_ids[i] = device_id;
+          return SCE_USBD_ATTACH_SUCCEEDED;
+        }
+      }
+
+      return SCE_USBD_ATTACH_FAILED;
+    }
+
     int i;
     for (i = 0; _devices[i].type != PAD_UNKNOWN; i++)
     {
@@ -340,6 +371,14 @@ int libvixen_attach(int device_id)
 
 int libvixen_detach(int device_id)
 {
+  for (int i = 0; i < MAX_CONTROLLERS; i++)
+  {
+    if (ultimate2_idle_device_ids[i] == device_id)
+    {
+      ultimate2_idle_device_ids[i] = -1;
+      return SCE_USBD_DETACH_SUCCEEDED;
+    }
+  }
 
   for (int i = 0; i < MAX_CONTROLLERS; i++)
   {


### PR DESCRIPTION
## Summary

Adds DInput support for the **8BitDo Ultimate 2 Wireless** controller when used with its 2.4 GHz receiver.

The controller enumerates as `2DC8:6012` while active in DInput mode. When the controller is powered off, the receiver re-enumerates as `2DC8:6013`. The idle receiver is claimed without allocating a controller slot, preventing the PSTV "This device is not supported" notification.

## Changes

* Add `2DC8:6012` as an 8BitDo Ultimate 2 Wireless DInput device.
* Add a dedicated parser for the Ultimate 2's DInput reports.
* Apply the required 8BitDo HID descriptor handling to `2DC8:6012`.
* Handle the idle `2DC8:6013` receiver without allocating a controller slot.
* Track idle receiver device IDs so their USB attach/detach lifecycle is handled cleanly.
* Map:

  * D-pad
  * A/B/X/Y
  * L1/R1
  * L2/R2
  * analog trigger values
  * Select/Start
  * PS/Home
  * L3/R3
  * left/right analog sticks

The additional L4/R4 and rear paddle inputs are intentionally left unmapped.

## DInput report

The controller was observed producing 34-byte DInput reports. The controls used by ViXEn are contained in the first portion of the report:

* byte 0: report ID
* byte 1: D-pad hat
* bytes 2-5: left/right analog sticks
* byte 6: right analog trigger
* byte 7: left analog trigger
* byte 8: face buttons, L1/R1 and additional paddle inputs
* byte 9: digital triggers, Select, Start, Home and L3/R3
* byte 10: L4/R4

## Receiver lifecycle

The 2.4 GHz receiver changes USB PID depending on controller state:

`2DC8:6013` — receiver idle / controller disconnected

`2DC8:6012` — controller connected in DInput mode

The idle `6013` receiver is recognized without creating a ViXEn controller. Its device ID is tracked so detach is handled successfully when the receiver re-enumerates. When `6012` appears, it follows the normal DInput controller path.

This avoids both phantom controller allocation and the PSTV unsupported-device notification while the controller is powered off.

## Hardware testing

Tested on a PlayStation TV running firmware 3.65.

Verified on real hardware:

* D-pad
* A/B/X/Y
* both analog sticks
* L1/R1
* L2/R2
* Select/Start
* L3/R3
* PS/Home
* controller power-off
* controller reconnect
* repeated `6013 -> 6012 -> 6013` receiver re-enumeration
* idle receiver produces no unsupported-device notification
* idle receiver does not consume a controller slot
* two Ultimate 2 Wireless controllers operate simultaneously using two 2.4 GHz receivers via USB hub

The controller must be connected in **DInput mode** (Power + B) for this implementation.

## AI disclosure

AI assistance was used during development for source-code analysis, USB report reverse engineering, debugging, implementation assistance, and review.

All resulting changes were manually reviewed, built from source, and tested on real PlayStation TV and 8BitDo Ultimate 2 Wireless hardware.
