### PR TITLE
Fix XInput interface discovery and add 8BitDo Ultimate 2 XInput support

### DIFF
--- a/src/controller.h
+++ b/src/controller.h
@@ -35,6 +35,7 @@ struct Controller
   SceUID pipe_in;
   SceUID pipe_out;
   SceUID pipe_control;
+  uint8_t usb_interface;
   unsigned char buffer[64] __attribute__((aligned(64)));
   size_t buffer_size;
   int vendor;

--- a/src/controllers/xbox_360_controller.c
+++ b/src/controllers/xbox_360_controller.c
@@ -9,90 +9,307 @@
 
 #define USB_IF_PROTOCOL 0x01
 
+/*
+ * The 8BitDo Ultimate 2 receiver requires this XInput output packet
+ * before it begins returning standard Xbox 360 input reports.
+ */
+static uint8_t ultimate2_xinput_init[3] __attribute__((aligned(64))) =
+    {0x01, 0x03, 0x02};
+
+
+/*
+ * Start interrupt-IN reads after the Ultimate 2 initialization
+ * packet completes successfully.
+ */
+static void Xbox360Controller_onUltimate2Init(
+    int32_t result,
+    int32_t count,
+    void *arg)
+{
+  Controller *c = (Controller *)arg;
+
+  if (!c)
+    return;
+
+  if (result != 0)
+  {
+    c->attached = 0;
+    c->inited = 0;
+    return;
+  }
+
+  usb_read(c);
+}
+
+
+/*
+ * Send the Ultimate 2 initialization packet after selecting its
+ * XInput interface.
+ */
+static void Xbox360Controller_onUltimate2SetInterface(
+    int32_t result,
+    int32_t count,
+    void *arg)
+{
+  Controller *c = (Controller *)arg;
+
+  if (!c)
+    return;
+
+  if (result != 0)
+  {
+    c->attached = 0;
+    c->inited = 0;
+    return;
+  }
+
+  if (c->pipe_out <= 0)
+  {
+    c->attached = 0;
+    c->inited = 0;
+    return;
+  }
+
+  int r = ksceUsbdInterruptTransfer(
+      c->pipe_out,
+      ultimate2_xinput_init,
+      sizeof(ultimate2_xinput_init),
+      Xbox360Controller_onUltimate2Init,
+      c);
+
+  if (r < 0)
+  {
+    c->attached = 0;
+    c->inited = 0;
+  }
+}
+
+
+/*
+ * Select alternate setting 0 of the discovered XInput interface
+ * after configuration completes.
+ */
+static void Xbox360Controller_onUltimate2Configuration(
+    int32_t result,
+    int32_t count,
+    void *arg)
+{
+  Controller *c = (Controller *)arg;
+
+  if (!c)
+    return;
+
+  if (result != 0)
+  {
+    c->attached = 0;
+    c->inited = 0;
+    return;
+  }
+
+  SceUsbdDeviceRequest set_interface;
+
+  set_interface.bmRequestType = 0x01;
+  set_interface.bRequest      = 0x0b;
+  set_interface.wValue        = 0;
+  set_interface.wIndex        = c->usb_interface;
+  set_interface.wLength       = 0;
+
+  int r = ksceUsbdControlTransfer(
+      c->pipe_control,
+      &set_interface,
+      NULL,
+      Xbox360Controller_onUltimate2SetInterface,
+      c);
+
+  if (r < 0)
+  {
+    c->attached = 0;
+    c->inited = 0;
+  }
+}
+
+
 uint8_t Xbox360Controller_probe(Controller *c, int device_id, int port)
 {
+  SceUsbdDeviceDescriptor *device;
+
+  device = (SceUsbdDeviceDescriptor *)ksceUsbdScanStaticDescriptor(
+      device_id, NULL, SCE_USBD_DESCRIPTOR_DEVICE);
+
+  if (!device)
+    return 0;
+
+  const int is_ultimate2 =
+      device->idVendor == 0x2dc8 &&
+      device->idProduct == 0x310b;
+
   c->type          = PAD_XBOX360;
   c->buffer_size   = 32;
   c->device_id     = device_id;
   c->port          = port;
   c->battery_level = 5;
+  c->pipe_in       = -1;
+  c->pipe_out      = -1;
+  c->pipe_control  = -1;
 
 #if defined(DEBUG)
-  ksceDebugPrintf("scanning endpoints for device %d\n", device_id);
+  ksceDebugPrintf("scanning XInput interface for device %d\n", device_id);
 #endif
 
-  // init endpoints and stuff
-
+  /*
+   * Find the actual XInput interface.
+   *
+   * Xbox 360 USB uses:
+   *   class    ff
+   *   subclass 5d
+   *   protocol 01
+   *
+   * This is important for composite devices such as the Ultimate 2.
+   */
   SceUsbdInterfaceDescriptor *interface;
-  interface = (SceUsbdInterfaceDescriptor *)ksceUsbdScanStaticDescriptor(device_id, 0, SCE_USBD_DESCRIPTOR_ENDPOINT);
+
+  interface = (SceUsbdInterfaceDescriptor *)ksceUsbdScanStaticDescriptor(
+      device_id,
+      NULL,
+      SCE_USBD_DESCRIPTOR_INTERFACE);
+
   while (interface)
   {
-    if (interface->bInterfaceProtocol == USB_IF_PROTOCOL)
+    if (interface->bInterfaceClass == 0xff &&
+        interface->bInterfaceSubclass == 0x5d &&
+        interface->bInterfaceProtocol == USB_IF_PROTOCOL)
       break;
-    interface = (SceUsbdInterfaceDescriptor *)ksceUsbdScanStaticDescriptor(device_id, interface,
-                                                                           SCE_USBD_DESCRIPTOR_ENDPOINT);
+
+    interface = (SceUsbdInterfaceDescriptor *)ksceUsbdScanStaticDescriptor(
+        device_id,
+        interface,
+        SCE_USBD_DESCRIPTOR_INTERFACE);
   }
 
+  if (!interface)
+    return 0;
+
+  c->usb_interface = interface->bInterfaceNumber;
+
+
+  /*
+   * Open interrupt endpoints belonging to the XInput interface.
+   */
   SceUsbdEndpointDescriptor *endpoint;
 
-  endpoint
-      = (SceUsbdEndpointDescriptor *)ksceUsbdScanStaticDescriptor(device_id, interface, SCE_USBD_DESCRIPTOR_ENDPOINT);
+  endpoint = (SceUsbdEndpointDescriptor *)ksceUsbdScanStaticDescriptor(
+      device_id,
+      interface,
+      SCE_USBD_DESCRIPTOR_ENDPOINT);
+
   while (endpoint)
   {
-#if defined(DEBUG)
-    ksceDebugPrintf("got EP: %02x\n", endpoint->bEndpointAddress);
-#endif
-    if ((endpoint->bEndpointAddress & SCE_USBD_ENDPOINT_DIRECTION_BITS) == SCE_USBD_ENDPOINT_DIRECTION_IN)
+    if ((endpoint->bEndpointAddress & SCE_USBD_ENDPOINT_DIRECTION_BITS) ==
+        SCE_USBD_ENDPOINT_DIRECTION_IN)
     {
-#if defined(DEBUG)
-      ksceDebugPrintf("opening in pipe\n");
-#endif
       c->pipe_in = ksceUsbdOpenPipe(device_id, endpoint);
-#if defined(DEBUG)
-      ksceDebugPrintf("= 0x%08x\n", c->pipe_in);
-      ksceDebugPrintf("bmAttributes = %x\n", endpoint->bmAttributes);
-#endif
+
+      c->buffer_size = endpoint->wMaxPacketSize;
+
+      if (c->buffer_size > sizeof(c->buffer))
+        return 0;
     }
-    else if ((endpoint->bEndpointAddress & SCE_USBD_ENDPOINT_DIRECTION_BITS) == SCE_USBD_ENDPOINT_DIRECTION_OUT)
+    else if ((endpoint->bEndpointAddress & SCE_USBD_ENDPOINT_DIRECTION_BITS) ==
+             SCE_USBD_ENDPOINT_DIRECTION_OUT)
     {
-#if defined(DEBUG)
-      ksceDebugPrintf("opening out pipe\n");
-#endif
       c->pipe_out = ksceUsbdOpenPipe(device_id, endpoint);
-#if defined(DEBUG)
-      ksceDebugPrintf("= 0x%08x\n", c->pipe_out);
-      ksceDebugPrintf("bmAttributes = %x\n", endpoint->bmAttributes);
-#endif
     }
 
     if (c->pipe_in > 0 && c->pipe_out > 0)
       break;
 
-    endpoint
-        = (SceUsbdEndpointDescriptor *)ksceUsbdScanStaticDescriptor(device_id, endpoint, SCE_USBD_DESCRIPTOR_ENDPOINT);
+    endpoint = (SceUsbdEndpointDescriptor *)ksceUsbdScanStaticDescriptor(
+        device_id,
+        endpoint,
+        SCE_USBD_DESCRIPTOR_ENDPOINT);
   }
 
-  if (c->pipe_in > 0 && c->pipe_out > 0)
+  if (c->pipe_in <= 0)
+    return 0;
+
+
+  /*
+   * Find configuration descriptor and open EP0.
+   */
+  SceUsbdConfigurationDescriptor *cdesc;
+
+  cdesc = (SceUsbdConfigurationDescriptor *)ksceUsbdScanStaticDescriptor(
+      device_id,
+      NULL,
+      SCE_USBD_DESCRIPTOR_CONFIGURATION);
+
+  if (!cdesc)
+    return 0;
+
+  c->pipe_control = ksceUsbdOpenPipe(device_id, NULL);
+
+  if (c->pipe_control < 0)
+    return 0;
+
+
+  /*
+   * The Ultimate 2 requires a serialized initialization sequence:
+   *
+   *   SET_CONFIGURATION
+   *   SET_INTERFACE(interface, alt 0)
+   *   interrupt OUT: 01 03 02
+   *   interrupt IN reads
+   */
+  if (is_ultimate2)
   {
-    SceUsbdConfigurationDescriptor *cdesc;
-    if ((cdesc = (SceUsbdConfigurationDescriptor *)ksceUsbdScanStaticDescriptor(device_id, NULL,
-                                                                                SCE_USBD_DESCRIPTOR_CONFIGURATION))
-        == NULL)
+    if (c->pipe_out <= 0)
       return 0;
 
-    SceUID control_pipe_id = ksceUsbdOpenPipe(device_id, NULL);
-    // set default config
-    int r = ksceUsbdSetConfiguration(control_pipe_id, cdesc->bConfigurationValue, NULL, NULL);
-#if defined(DEBUG)
-    ksceDebugPrintf("ksceUsbdSetConfiguration = 0x%08x\n", r);
-#endif
-    if (r < 0)
-      return 0;
+    /*
+     * libvixen_attach() requires inited to be true when probe returns.
+     * Actual input starts asynchronously after the sequence above.
+     */
     c->attached = 1;
-    c->inited   = 1;
+    c->inited = 1;
+
+    int r = ksceUsbdSetConfiguration(
+        c->pipe_control,
+        cdesc->bConfigurationValue,
+        Xbox360Controller_onUltimate2Configuration,
+        c);
+
+    if (r < 0)
+    {
+      c->attached = 0;
+      c->inited = 0;
+      return 0;
+    }
+
+    return 1;
   }
+
+
+  /*
+   * Preserve normal upstream behavior for every other XInput device.
+   */
+  int r = ksceUsbdSetConfiguration(
+      c->pipe_control,
+      cdesc->bConfigurationValue,
+      NULL,
+      NULL);
+
+#if defined(DEBUG)
+  ksceDebugPrintf("ksceUsbdSetConfiguration = 0x%08x\n", r);
+#endif
+
+  if (r < 0)
+    return 0;
+
+  c->attached = 1;
+  c->inited = 1;
 
   usb_read(c);
+
   return 1;
 }
 

--- a/src/devicelist.c
+++ b/src/devicelist.c
@@ -15,7 +15,8 @@
 #include "controllers/dinput/neogeox.h"
 #include "controllers/dinput/8bitdoadapter.h"
 
-gamepad_t _devices[] = {{PAD_XBOX360, 0x045e, 0x028e, NULL},  // Microsoft X-Box 360 pad
+gamepad_t _devices[] = {{PAD_XBOX360, 0x2dc8, 0x310b, NULL},  // 8BitDo Ultimate 2 Wireless (XInput)
+                        {PAD_XBOX360, 0x045e, 0x028e, NULL},  // Microsoft X-Box 360 pad
                         {PAD_XBOX360, 0x045e, 0x028f, NULL},  // Microsoft X-Box 360 pad v2
                         {PAD_XBOX360, 0x0738, 0x4716, NULL},  // Mad Catz Wired Xbox 360 Controller
                         {PAD_XBOX360, 0x0738, 0x4726, NULL},  // Mad Catz Xbox 360 Controller


### PR DESCRIPTION
## Summary

Adds XInput support for the 8BitDo Ultimate 2 Wireless controller (`2dc8:310b`) and fixes Xbox 360 interface discovery for composite USB devices.

The Ultimate 2 exposes multiple USB interfaces, so ViXEn must explicitly locate the Xbox 360-compatible vendor interface (`ff/5d/01`) rather than scanning endpoint descriptors without first selecting the correct interface.

The receiver also requires a short initialization sequence before it begins returning standard Xbox 360 input reports:

1. Set the USB configuration.
2. Select alternate setting 0 of the discovered XInput interface.
3. Send `01 03 02` to the interrupt-OUT endpoint.
4. Begin normal interrupt-IN reads.

VID/PID detection is performed using the USB device descriptor so the Ultimate 2-specific initialization path is only used for `2dc8:310b`. Existing XInput devices retain the normal ViXEn initialization path.

## Tested

Tested on PlayStation TV with 8BitDo Ultimate 2 Wireless controllers in XInput mode.

* Single controller input works.
* Two Ultimate 2 controllers work simultaneously.
* Standard Xbox 360 report parsing works.
* No changes are required to the generic USB read path.

Controller port allocation is intentionally outside the scope of this PR and is handled separately.

## AI assistance

AI assistance was used during investigation, implementation, and code review. The changes were tested on physical PlayStation TV and 8BitDo Ultimate 2 hardware.
